### PR TITLE
Export compatibility with mongo 2.6.x

### DIFF
--- a/commands
+++ b/commands
@@ -117,7 +117,7 @@ case "$1" in
     PASSWORD="$(cat "$SERVICE_ROOT/PASSWORD")"
 
     [[ -n $SSH_TTY ]] && stty -opost
-    docker exec "$SERVICE_NAME" bash -c "DIR=\$(mktemp -d) && mongodump -d $SERVICE -o=\"\$DIR\" -u \"$SERVICE\" -p \"$PASSWORD\" --authenticationDatabase \"$SERVICE\" && tar cf - -C \"\$DIR\" . && rm -rf \"\$DIR\""
+    docker exec "$SERVICE_NAME" bash -c "DIR=\$(mktemp -d) && mongodump -d $SERVICE -o \"\$DIR\" -u \"$SERVICE\" -p \"$PASSWORD\" --authenticationDatabase \"$SERVICE\" && tar cf - -C \"\$DIR\" . && rm -rf \"\$DIR\""
     [[ -n $SSH_TTY ]] && stty opost
     ;;
 

--- a/commands
+++ b/commands
@@ -117,7 +117,7 @@ case "$1" in
     PASSWORD="$(cat "$SERVICE_ROOT/PASSWORD")"
 
     [[ -n $SSH_TTY ]] && stty -opost
-    docker exec "$SERVICE_NAME" bash -c "DIR=\$(mktemp -d) && mongodump -d $SERVICE -o \"\$DIR\" -u \"$SERVICE\" -p \"$PASSWORD\" --authenticationDatabase \"$SERVICE\" && tar cf - -C \"\$DIR\" . && rm -rf \"\$DIR\""
+    docker exec "$SERVICE_NAME" bash -c "DIR=\$(mktemp -d) && mongodump -d $SERVICE -o \"\$DIR\" -u \"$SERVICE\" -p \"$PASSWORD\" --authenticationDatabase \"$SERVICE\" 1>&2 && tar cf - -C \"\$DIR\" . && rm -rf \"\$DIR\""
     [[ -n $SSH_TTY ]] && stty opost
     ;;
 

--- a/tests/service_export.bats
+++ b/tests/service_export.bats
@@ -25,6 +25,6 @@ teardown() {
   export ECHO_DOCKER_COMMAND="true"
   run dokku "$PLUGIN_COMMAND_PREFIX:export" l
   password="$(cat "$PLUGIN_DATA_ROOT/l/PASSWORD")"
-  assert_output "docker exec dokku.mongo.l bash -c DIR=\$(mktemp -d) && mongodump -d l -o=\"\$DIR\" -u \"l\" -p \"$password\" --authenticationDatabase \"l\" && tar cf - -C \"\$DIR\" . && rm -rf \"\$DIR\""
+  assert_output "docker exec dokku.mongo.l bash -c DIR=\$(mktemp -d) && mongodump -d l -o \"\$DIR\" -u \"l\" -p \"$password\" --authenticationDatabase \"l\" && tar cf - -C \"\$DIR\" . && rm -rf \"\$DIR\""
 }
 

--- a/tests/service_export.bats
+++ b/tests/service_export.bats
@@ -25,6 +25,6 @@ teardown() {
   export ECHO_DOCKER_COMMAND="true"
   run dokku "$PLUGIN_COMMAND_PREFIX:export" l
   password="$(cat "$PLUGIN_DATA_ROOT/l/PASSWORD")"
-  assert_output "docker exec dokku.mongo.l bash -c DIR=\$(mktemp -d) && mongodump -d l -o \"\$DIR\" -u \"l\" -p \"$password\" --authenticationDatabase \"l\" && tar cf - -C \"\$DIR\" . && rm -rf \"\$DIR\""
+  assert_output "docker exec dokku.mongo.l bash -c DIR=\$(mktemp -d) && mongodump -d l -o \"\$DIR\" -u \"l\" -p \"$password\" --authenticationDatabase \"l\" 1>&2 && tar cf - -C \"\$DIR\" . && rm -rf \"\$DIR\""
 }
 


### PR DESCRIPTION
The -o= seems to work fine in 3.x but in 2.x it actually includes the equals sign in the path, resulting in "/=/tmp/tmp.XXXXXX". The mongodump command docs for neither 2.x nor 3.x list the equals sign as part of the -o or --out parameter. It seems to work fine in 3.x with or without the equals sign.
